### PR TITLE
Добавлена фильтрация имён в HLOD

### DIFF
--- a/com.unity.hlod/Editor/HLODCreator.cs
+++ b/com.unity.hlod/Editor/HLODCreator.cs
@@ -188,7 +188,7 @@ namespace Unity.HLODSystem
 
                 Bounds bounds = hlod.GetBounds();
 
-                List<GameObject> hlodTargets = ObjectUtils.HLODTargets(hlod.gameObject, hlod.TagFilter);
+                List<GameObject> hlodTargets = ObjectUtils.HLODTargets(hlod.gameObject, hlod.TagFilter, hlod.IgnoreNamePatterns);
                 ISpaceSplitter spliter = SpaceSplitterTypes.CreateInstance(hlod);
                 if (spliter == null)
                 {

--- a/com.unity.hlod/Editor/HLODEditor.cs
+++ b/com.unity.hlod/Editor/HLODEditor.cs
@@ -32,6 +32,7 @@ namespace Unity.HLODSystem
         private SerializedProperty m_CullDistanceProperty;
         private SerializedProperty m_MinObjectSizeProperty;
         private SerializedProperty m_TagFilterProperty;
+        private SerializedProperty m_IgnoreNamePatternsProperty;
 
         private LODSlider m_LODSlider;
 
@@ -78,6 +79,7 @@ namespace Unity.HLODSystem
             m_CullDistanceProperty = serializedObject.FindProperty("m_CullDistance");
             m_MinObjectSizeProperty = serializedObject.FindProperty("m_MinObjectSize");
             m_TagFilterProperty = serializedObject.FindProperty("m_TagFilter");
+            m_IgnoreNamePatternsProperty = serializedObject.FindProperty("m_IgnoreNamePatterns");
 
             m_LODSlider = new LODSlider(true, "Cull");
             m_LODSlider.InsertRange("High", m_LODDistanceProperty);
@@ -142,6 +144,7 @@ namespace Unity.HLODSystem
                 m_LODSlider.Draw();
                 EditorGUILayout.PropertyField(m_MinObjectSizeProperty);
                 EditorGUILayout.PropertyField(m_TagFilterProperty, new GUIContent("Tag Filter"));
+                EditorGUILayout.PropertyField(m_IgnoreNamePatternsProperty, new GUIContent("Ignore Name Patterns"), true);
             }
             EditorGUILayout.EndFoldoutHeaderGroup();
 

--- a/com.unity.hlod/Editor/Utils/ObjectUtils.cs
+++ b/com.unity.hlod/Editor/Utils/ObjectUtils.cs
@@ -33,7 +33,7 @@ namespace Unity.HLODSystem.Utils
             return result.ToList();
         }
 
-        public static List<GameObject> HLODTargets(GameObject root, string tagFilter = null)
+        public static List<GameObject> HLODTargets(GameObject root, string tagFilter = null, IEnumerable<string> ignoreNamePatterns = null)
         {
             List<GameObject> targets = new List<GameObject>();
 
@@ -91,6 +91,17 @@ namespace Unity.HLODSystem.Utils
             if (string.IsNullOrEmpty(tagFilter) == false)
             {
                 results = results.Where(t => t.CompareTag(tagFilter)).ToList();
+            }
+
+            if (ignoreNamePatterns != null)
+            {
+                var patterns = ignoreNamePatterns.Where(p => string.IsNullOrEmpty(p) == false)
+                                                .Select(p => p.ToLowerInvariant()).ToList();
+                if (patterns.Count > 0)
+                {
+                    results = results.Where(t =>
+                        patterns.All(p => t.name.ToLowerInvariant().Contains(p) == false)).ToList();
+                }
             }
 
             return results;

--- a/com.unity.hlod/Runtime/HLOD.cs
+++ b/com.unity.hlod/Runtime/HLOD.cs
@@ -23,6 +23,8 @@ namespace Unity.HLODSystem
         private float m_MinObjectSize = 0.0f;
         [SerializeField]
         private string m_TagFilter = "";
+        [SerializeField]
+        private List<string> m_IgnoreNamePatterns = new List<string>{"Collider", "NavMesh", "low"};
 
         private Type m_SpaceSplitterType;
         private Type m_BatcherType;
@@ -126,6 +128,11 @@ namespace Unity.HLODSystem
         {
             set { m_MinObjectSize = value; }
             get { return m_MinObjectSize; }
+        }
+
+        public List<string> IgnoreNamePatterns
+        {
+            get { return m_IgnoreNamePatterns; }
         }
 
         public string TagFilter


### PR DESCRIPTION
## Summary
- добавлен список `IgnoreNamePatterns` в компонент HLOD
- редактор HLOD теперь позволяет задавать паттерны в инспекторе
- обновлены функции генерации, чтобы исключать объекты по именам

## Testing
- `npm test` *(ожидался `package.json`, команда упала)*

------
https://chatgpt.com/codex/tasks/task_e_685a6bf07b4c8328a481dc73b3d5b439