### PR TITLE
Improve ignore pattern handling in HLOD targets

### DIFF
--- a/com.unity.hlod/Editor/Utils/ObjectUtils.cs
+++ b/com.unity.hlod/Editor/Utils/ObjectUtils.cs
@@ -89,7 +89,7 @@ namespace Unity.HLODSystem.Utils{
                     .ToList();
                 if (patterns.Count > 0){
                     results = results.Where(t =>
-                        patterns.All(p => t.name.ToLowerInvariant().Contains(p) == false)).ToList();
+                        ContainsPatternInHierarchy(t, patterns, root) == false).ToList();
                 }
             }
 
@@ -117,6 +117,43 @@ namespace Unity.HLODSystem.Utils{
 
         private static GameObject GetParent(GameObject go){
             return go.transform.parent.gameObject;
+        }
+
+        private static bool ContainsPattern(string name, List<string> patterns){
+            string lower = name.ToLowerInvariant();
+            for (int i = 0; i < patterns.Count; ++i){
+                if (lower.Contains(patterns[i]))
+                    return true;
+            }
+            return false;
+        }
+
+        private static bool ContainsPatternInHierarchy(GameObject obj, List<string> patterns, GameObject root){
+            GameObject current = obj;
+            while (current != null){
+                if (ContainsPattern(current.name, patterns))
+                    return true;
+                if (current == root)
+                    break;
+                if (current.transform.parent == null)
+                    break;
+                current = current.transform.parent.gameObject;
+            }
+
+            Queue<Transform> queue = new Queue<Transform>();
+            foreach (Transform child in obj.transform){
+                queue.Enqueue(child);
+            }
+            while (queue.Count > 0){
+                Transform tr = queue.Dequeue();
+                if (ContainsPattern(tr.gameObject.name, patterns))
+                    return true;
+                foreach (Transform child in tr){
+                    queue.Enqueue(child);
+                }
+            }
+
+            return false;
         }
 
 


### PR DESCRIPTION
## Summary
- filter HLOD candidates by scanning parent and child names for ignore patterns
- add helpers to traverse object hierarchies when matching names

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab0b5def88328ada12cfc790cdcda